### PR TITLE
add application/wasm

### DIFF
--- a/src/mimeData.json
+++ b/src/mimeData.json
@@ -963,6 +963,22 @@
     ]
   },
   {
+    "name": "application/wasm",
+    "description": "A wasm binary allowed to be used with WebAssembly.instantiateStreaming",
+    "types": [
+      ".wasm"
+    ],
+    "furtherReading": [
+      {
+        "title": "IANA website on the media type",
+        "url": "https://www.iana.org/assignments/media-types/application/wasm"
+      },
+      {
+        "title": "how ",
+        "url": ""
+    ]
+  },
+  {
     "name": "application/x-cpio",
     "description": "",
     "types": [

--- a/src/mimeData.json
+++ b/src/mimeData.json
@@ -974,8 +974,9 @@
         "url": "https://www.iana.org/assignments/media-types/application/wasm"
       },
       {
-        "title": "how ",
-        "url": ""
+        "title": "w3 on the web api for streaming webassembly instanciation",
+        "url": "https://www.w3.org/TR/wasm-web-api-2/#streaming-modules"
+      }
     ]
   },
   {

--- a/src/mimeData.json
+++ b/src/mimeData.json
@@ -964,17 +964,18 @@
   },
   {
     "name": "application/wasm",
-    "description": "A wasm binary allowed to be used with WebAssembly.instantiateStreaming",
+    "description": "A WASM binary allowed to be used with WebAssembly.instantiateStreaming.",
     "types": [
       ".wasm"
     ],
+    "alternatives": [],
     "furtherReading": [
       {
-        "title": "IANA website on the media type",
+        "title": "Internet Assigned Numbers Authority (IANA)",
         "url": "https://www.iana.org/assignments/media-types/application/wasm"
       },
       {
-        "title": "w3 on the web api for streaming webassembly instanciation",
+        "title": "W3C - Streaming Module Compilation and Instantiation",
         "url": "https://www.w3.org/TR/wasm-web-api-2/#streaming-modules"
       }
     ]


### PR DESCRIPTION
application/wasm is required for a .wasm binary to be compiled instanciated on-the-fly from a js fetch.

[IANA website on the media type](https://www.iana.org/assignments/media-types/application/wasm)
[w3 on the web api for streaming webassembly instanciation](https://www.w3.org/TR/wasm-web-api-2/#streaming-modules)